### PR TITLE
[#185] Enter/Esc support for all dialogues

### DIFF
--- a/src/function/FunctionDiagram.ts
+++ b/src/function/FunctionDiagram.ts
@@ -9,6 +9,7 @@ import {paper} from "../main/DiagramCanvas";
 
 export function changeDiagrams(diagram: number = 0) {
     graph.clear();
+    ProjectSettings.selectedLink = "";
     if (Diagrams[diagram]) {
         ProjectSettings.selectedDiagram = diagram;
         for (let id in ProjectElements) {

--- a/src/main/NewLinkModal.tsx
+++ b/src/main/NewLinkModal.tsx
@@ -40,7 +40,6 @@ export default class NewLinkModal extends React.Component<Props, State> {
 
 	handleChangeLink(event: React.ChangeEvent<HTMLSelectElement>) {
 		this.setState({selectedLink: event.currentTarget.value});
-		if (event.currentTarget.value !== "") this.props.close(event.currentTarget.value);
 	}
 
 	filtering(link: string): boolean {
@@ -110,9 +109,15 @@ export default class NewLinkModal extends React.Component<Props, State> {
 	}
 
 	render() {
+		let options = this.getLinks().sort();
 		return (<Modal centered scrollable show={this.props.modal}
 					   onHide={() => this.props.close}
-					   onEntering={() => this.setState({selectedLink: ""})}
+					   onEntering={() => {
+						   this.setState({selectedLink: options.length > 0 ? options[0] : ""});
+						   let input = document.getElementById("newLinkInputSelect");
+						   if (input) input.focus();
+					   }}
+					   keyboard onEscapeKeyDown={() => this.props.close()}
 		>
 			<Modal.Header>
 				<Modal.Title>{Locale[ProjectSettings.viewLanguage].modalNewLinkTitle}</Modal.Title>
@@ -132,13 +137,20 @@ export default class NewLinkModal extends React.Component<Props, State> {
                         htmlFor={"displayIncompatible"}>{Locale[ProjectSettings.viewLanguage].showIncompatibleLinks}</label>
 				</span>}
 				<br/>
-				<Form.Control htmlSize={Object.keys(Links).length} as="select" value={this.state.selectedLink}
-							  onChange={this.handleChangeLink}>
-					{this.getLinks().sort().map((link) => (
-						<option key={link}
-								onClick={() => this.setLink(link)}
-								value={link}>{getLabelOrBlank(getLinkOrVocabElem(link).labels, this.props.projectLanguage)}</option>))}
-				</Form.Control>
+				<Form onSubmit={event => {
+					event.preventDefault();
+					if (this.state.selectedLink !== "") this.props.close(this.state.selectedLink);
+				}}>
+					<Form.Control htmlSize={Object.keys(Links).length} as="select" value={this.state.selectedLink}
+								  onChange={this.handleChangeLink}
+									id={"newLinkInputSelect"}>
+						{options.map((link) => (
+							<option key={link}
+									onClick={() => this.setLink(link)}
+									value={link}>{getLabelOrBlank(getLinkOrVocabElem(link).labels, this.props.projectLanguage)}</option>))}
+					</Form.Control>
+					<button style={{display: "none"}}/>
+				</Form>
 			</Modal.Body>
 			<Modal.Footer>
 				<Button onClick={() => {

--- a/src/panels/DiagramPanel.tsx
+++ b/src/panels/DiagramPanel.tsx
@@ -26,20 +26,22 @@ export default class DiagramPanel extends React.Component<Props, State> {
 
 	render() {
 		return (<div className={"diagramPanel" + (this.props.error ? " disabled" : "")}>
-			{Diagrams.map((diag, i) => {
-				if (diag.active) return (<DiagramTab key={i} diagram={i} name={diag.name}
-													 error={this.props.error}
-													 update={() => {
-														 this.forceUpdate();
-														 this.props.update();
-													 }}
-													 performTransaction={this.props.performTransaction}/>)
-				else return "";
-			})}
+			{Diagrams.filter(diag => diag.active).map((diag, i) =>
+				<DiagramTab key={i}
+							diagram={i}
+							update={() => {
+								this.forceUpdate();
+								this.props.update();
+							}}
+							performTransaction={this.props.performTransaction}
+							deleteDiagram={(diag: number) => {
+								this.setState({selectedDiagram: diag, modalRemoveDiagram: true});
+							}}/>
+			)}
 			<DiagramAdd update={() => {
 				this.forceUpdate();
 				this.props.update();
-			}} error={this.props.error} performTransaction={this.props.performTransaction}/>
+			}} performTransaction={this.props.performTransaction}/>
 			<ModalRemoveDiagram
 				modal={this.state.modalRemoveDiagram}
 				diagram={this.state.selectedDiagram}
@@ -48,6 +50,7 @@ export default class DiagramPanel extends React.Component<Props, State> {
 				}}
 				update={() => {
 					this.forceUpdate();
+					this.props.update();
 				}}
 				performTransaction={this.props.performTransaction}
 			/>

--- a/src/panels/diagram/DiagramAdd.tsx
+++ b/src/panels/diagram/DiagramAdd.tsx
@@ -5,7 +5,6 @@ import {Locale} from "../../config/Locale";
 
 interface Props {
 	update: Function;
-	error: boolean;
 	performTransaction: (transaction: { add: string[], delete: string[], update: string[] }) => void;
 }
 
@@ -24,7 +23,7 @@ export default class DiagramAdd extends React.Component<Props, State> {
 	}
 
 	render() {
-		return (<div className={"diagramTab" + (this.props.error ? " disabled" : "")}>
+		return (<div className={"diagramTab"}>
 			<button className={"buttonlink nounderline"} onClick={() => {
 				this.addDiagram();
 			}}>

--- a/src/panels/diagram/DiagramTab.tsx
+++ b/src/panels/diagram/DiagramTab.tsx
@@ -6,11 +6,10 @@ import {RIEInput} from "riek";
 import {updateProjectSettings} from "../../interface/TransactionInterface";
 
 interface Props {
-	name: string;
 	diagram: number;
 	update: Function;
+	deleteDiagram: Function;
 	performTransaction: (transaction: { add: string[], delete: string[], update: string[] }) => void;
-	error: boolean;
 }
 
 interface State {
@@ -19,43 +18,36 @@ interface State {
 
 export default class DiagramTab extends React.Component<Props, State> {
 
-	deleteDiagram() {
-		Diagrams[this.props.diagram].active = false;
-		if (this.props.diagram < ProjectSettings.selectedDiagram) changeDiagrams(ProjectSettings.selectedDiagram - 1);
-		else if (this.props.diagram === ProjectSettings.selectedDiagram) changeDiagrams(0);
-		this.props.update();
-		this.props.performTransaction(updateProjectSettings(ProjectSettings.contextIRI));
-	}
-
 	changeDiagram() {
 		changeDiagrams(this.props.diagram);
 		this.props.update();
-		ProjectSettings.selectedLink = "";
 	}
 
 	handleChangeDiagramName(event: { textarea: string }) {
-		Diagrams[this.props.diagram].name = event.textarea;
-		this.props.performTransaction(updateProjectSettings(ProjectSettings.contextIRI));
-		this.forceUpdate();
-		this.props.update();
+		if (event.textarea.length > 0){
+			Diagrams[this.props.diagram].name = event.textarea;
+			this.props.performTransaction(updateProjectSettings(ProjectSettings.contextIRI));
+			this.forceUpdate();
+			this.props.update();
+		}
 	}
 
 	render() {
 		return (
 			<div
-				className={"diagramTab" + (this.props.diagram === ProjectSettings.selectedDiagram ? " selected" : "") + (this.props.error ? " disabled" : "")}
+				className={"diagramTab" + (this.props.diagram === ProjectSettings.selectedDiagram ? " selected" : "")}
 				onClick={() => this.changeDiagram()}>
 				{this.props.diagram === ProjectSettings.selectedDiagram ? <RIEInput
 					className={"rieinput"}
-					value={this.props.name.length > 0 ? this.props.name : "<blank>"}
+					value={Diagrams[this.props.diagram].name}
 					change={(event: { textarea: string }) => {
 						this.handleChangeDiagramName(event);
 					}}
 					propName="textarea"
-				/> : this.props.name}
+				/> : Diagrams[this.props.diagram].name}
 				{Diagrams.filter(diag => diag.active).length > 1 && <button className={"buttonlink"} onClick={(evt) => {
 					evt.stopPropagation();
-					this.deleteDiagram();
+					this.props.deleteDiagram(this.props.diagram);
 				}}>
                     <span role="img" aria-label={""}>&nbsp;❌</span>
                 </button>}

--- a/src/panels/menu/misc/AboutModal.tsx
+++ b/src/panels/menu/misc/AboutModal.tsx
@@ -15,7 +15,7 @@ interface State {
 export default class AboutModal extends React.Component<Props, State> {
 
     render() {
-        return (<Modal centered scrollable show={this.props.modal}>
+        return (<Modal centered scrollable show={this.props.modal} keyboard onEscapeKeyDown={() => this.props.close()}>
 			<Modal.Header>
 				<Modal.Title>{Locale[ProjectSettings.viewLanguage].changelog}</Modal.Title>
 			</Modal.Header>

--- a/src/panels/menu/misc/HelpModal.tsx
+++ b/src/panels/menu/misc/HelpModal.tsx
@@ -15,7 +15,7 @@ interface State {
 export default class HelpModal extends React.Component<Props, State> {
 
     render() {
-        return (<Modal centered show={this.props.modal}>
+        return (<Modal centered show={this.props.modal} keyboard onEscapeKeyDown={() => this.props.close()}>
             <Modal.Header>
                 <Modal.Title>{Locale[ProjectSettings.viewLanguage].help}</Modal.Title>
             </Modal.Header>

--- a/src/panels/modal/ModalRemoveDiagram.tsx
+++ b/src/panels/modal/ModalRemoveDiagram.tsx
@@ -37,9 +37,6 @@ export default class ModalRemoveDiagram extends React.Component<Props> {
 					<p>{Locale[ProjectSettings.viewLanguage].modalRemoveDiagramDescription}</p>
 				</Modal.Body>
 				<Modal.Footer>
-					<Button onClick={() => {
-						this.setState({modalRemove: false});
-					}} variant="secondary">{Locale[ProjectSettings.viewLanguage].cancel}</Button>
 					<Form onSubmit={(event => {
 						event.preventDefault();
 						this.save();
@@ -49,6 +46,9 @@ export default class ModalRemoveDiagram extends React.Component<Props> {
 						<Button id={"modalRemoveDiagramConfirm"}
 								type={"submit"}>{Locale[ProjectSettings.viewLanguage].confirm}</Button>
 					</Form>
+					<Button onClick={() => {
+						this.props.close();
+					}} variant="secondary">{Locale[ProjectSettings.viewLanguage].cancel}</Button>
 				</Modal.Footer>
 			</Modal>
 		);

--- a/src/panels/modal/ModalRemoveDiagram.tsx
+++ b/src/panels/modal/ModalRemoveDiagram.tsx
@@ -25,7 +25,11 @@ export default class ModalRemoveDiagram extends React.Component<Props> {
 
 	render() {
 		return (
-			<Modal centered show={this.props.modal} keyboard onEscapeKeyDown={() => this.props.close()}>
+			<Modal centered show={this.props.modal} keyboard onEscapeKeyDown={() => this.props.close()}
+				   onEntering={() => {
+					   let elem = document.getElementById("modalRemoveDiagramConfirm");
+					   if (elem) elem.focus();
+				   }}>
 				<Modal.Header>
 					<Modal.Title>{Locale[ProjectSettings.viewLanguage].modalRemoveDiagramTitle}</Modal.Title>
 				</Modal.Header>
@@ -42,7 +46,8 @@ export default class ModalRemoveDiagram extends React.Component<Props> {
 						this.props.update();
 						this.props.close();
 					})}>
-						<Button type={"submit"}>{Locale[ProjectSettings.viewLanguage].confirm}</Button>
+						<Button id={"modalRemoveDiagramConfirm"}
+								type={"submit"}>{Locale[ProjectSettings.viewLanguage].confirm}</Button>
 					</Form>
 				</Modal.Footer>
 			</Modal>

--- a/src/panels/modal/ModalRemoveDiagram.tsx
+++ b/src/panels/modal/ModalRemoveDiagram.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Button, Modal} from "react-bootstrap";
+import {Button, Form, Modal} from "react-bootstrap";
 import {Diagrams, ProjectSettings} from "../../config/Variables";
 import {changeDiagrams} from "../../function/FunctionDiagram";
 import {updateProjectSettings} from "../../interface/TransactionInterface";
@@ -17,15 +17,15 @@ export default class ModalRemoveDiagram extends React.Component<Props> {
 
 	save() {
 		Diagrams[this.props.diagram].active = false;
-		if (ProjectSettings.selectedDiagram === this.props.diagram) {
-			changeDiagrams(0);
-		}
+		if (this.props.diagram < ProjectSettings.selectedDiagram) changeDiagrams(ProjectSettings.selectedDiagram - 1);
+		else if (this.props.diagram === ProjectSettings.selectedDiagram) changeDiagrams(0);
+		this.props.update();
 		this.props.performTransaction(updateProjectSettings(ProjectSettings.contextIRI));
 	}
 
 	render() {
 		return (
-			<Modal centered show={this.props.modal}>
+			<Modal centered show={this.props.modal} keyboard onEscapeKeyDown={() => this.props.close()}>
 				<Modal.Header>
 					<Modal.Title>{Locale[ProjectSettings.viewLanguage].modalRemoveDiagramTitle}</Modal.Title>
 				</Modal.Header>
@@ -36,11 +36,14 @@ export default class ModalRemoveDiagram extends React.Component<Props> {
 					<Button onClick={() => {
 						this.setState({modalRemove: false});
 					}} variant="secondary">{Locale[ProjectSettings.viewLanguage].cancel}</Button>
-					<Button onClick={() => {
+					<Form onSubmit={(event => {
+						event.preventDefault();
 						this.save();
 						this.props.update();
 						this.props.close();
-					}}>{Locale[ProjectSettings.viewLanguage].confirm}</Button>
+					})}>
+						<Button type={"submit"}>{Locale[ProjectSettings.viewLanguage].confirm}</Button>
+					</Form>
 				</Modal.Footer>
 			</Modal>
 		);

--- a/src/panels/modal/ModalRemoveItem.tsx
+++ b/src/panels/modal/ModalRemoveItem.tsx
@@ -31,7 +31,11 @@ export default class ModalRemoveItem extends React.Component<Props, State> {
 
     render() {
         return (
-            <Modal centered show={this.props.modal} keyboard onEscapeKeyDown={() => this.props.close()}>
+            <Modal centered show={this.props.modal} keyboard onEscapeKeyDown={() => this.props.close()}
+                   onEntering={() => {
+                       let elem = document.getElementById("modalRemoveItemConfirm");
+                       if (elem) elem.focus();
+                   }}>
                 <Modal.Header>
                     <Modal.Title>{Locale[ProjectSettings.viewLanguage].modalRemovePackageItemTitle}</Modal.Title>
                 </Modal.Header>
@@ -48,7 +52,8 @@ export default class ModalRemoveItem extends React.Component<Props, State> {
                         this.props.close();
                         this.props.update();
                     }}>
-                    <Button>{Locale[ProjectSettings.viewLanguage].confirm}</Button>
+                        <Button type={"submit"}
+                                id={"modalRemoveItemConfirm"}>{Locale[ProjectSettings.viewLanguage].confirm}</Button>
                     </Form>
                 </Modal.Footer>
             </Modal>

--- a/src/panels/modal/ModalRemoveItem.tsx
+++ b/src/panels/modal/ModalRemoveItem.tsx
@@ -43,9 +43,6 @@ export default class ModalRemoveItem extends React.Component<Props, State> {
                     <p>{Locale[ProjectSettings.viewLanguage].modalRemovePackageItemDescription}</p>
                 </Modal.Body>
                 <Modal.Footer>
-                    <Button onClick={() => {
-                        this.props.close();
-                    }} variant="secondary">{Locale[ProjectSettings.viewLanguage].cancel}</Button>
                     <Form onSubmit={event => {
                         event.preventDefault();
                         this.save();
@@ -55,6 +52,9 @@ export default class ModalRemoveItem extends React.Component<Props, State> {
                         <Button type={"submit"}
                                 id={"modalRemoveItemConfirm"}>{Locale[ProjectSettings.viewLanguage].confirm}</Button>
                     </Form>
+                    <Button onClick={() => {
+                        this.props.close();
+                    }} variant="secondary">{Locale[ProjectSettings.viewLanguage].cancel}</Button>
                 </Modal.Footer>
             </Modal>
         );

--- a/src/panels/modal/ModalRemoveItem.tsx
+++ b/src/panels/modal/ModalRemoveItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Button, Modal} from "react-bootstrap";
+import {Button, Form, Modal} from "react-bootstrap";
 import {deletePackageItem} from "../../function/FunctionEditVars";
 import {mergeTransactions, updateDeleteTriples} from "../../interface/TransactionInterface";
 import {ProjectElements, ProjectSettings, Schemes, VocabularyElements} from "../../config/Variables";
@@ -31,7 +31,7 @@ export default class ModalRemoveItem extends React.Component<Props, State> {
 
     render() {
         return (
-            <Modal centered show={this.props.modal}>
+            <Modal centered show={this.props.modal} keyboard onEscapeKeyDown={() => this.props.close()}>
                 <Modal.Header>
                     <Modal.Title>{Locale[ProjectSettings.viewLanguage].modalRemovePackageItemTitle}</Modal.Title>
                 </Modal.Header>
@@ -42,11 +42,14 @@ export default class ModalRemoveItem extends React.Component<Props, State> {
                     <Button onClick={() => {
                         this.props.close();
                     }} variant="secondary">{Locale[ProjectSettings.viewLanguage].cancel}</Button>
-                    <Button onClick={() => {
+                    <Form onSubmit={event => {
+                        event.preventDefault();
                         this.save();
                         this.props.close();
                         this.props.update();
-                    }}>{Locale[ProjectSettings.viewLanguage].confirm}</Button>
+                    }}>
+                    <Button>{Locale[ProjectSettings.viewLanguage].confirm}</Button>
+                    </Form>
                 </Modal.Footer>
             </Modal>
         );


### PR DESCRIPTION
## Affected issues
* Closes #185.
## Detailed changes:
* All dialogues now respond to Escape (and Enter, where appropriate).
* Diagram deletion confirmation dialogue restored.
* In the New Relationship dialogue, the arrow keys and Enter can now be used to navigate the relationship type list.
## Deploy previews:
* [JaKl Obchodní rejstřík](https://deploy-preview-193--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance201242184)
* [V-SGoV pro číselníky](https://deploy-preview-193--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance-145753951)
* [GSGoV klasifikací a číselníků](https://deploy-preview-193--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance2045554666)
* [Sbírka](https://deploy-preview-193--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance1178651091)
* [mm-test](https://deploy-preview-193--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance-2000996011)
* [Marie test](https://deploy-preview-193--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance-530560086)
* [Datové fondy VS](https://deploy-preview-193--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance-1153182747)
* [ontoGrapher test](https://deploy-preview-193--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance1087289886)
* [ML test](https://deploy-preview-193--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance-1101091271)
* [Karel TestX](https://deploy-preview-193--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance1170301076)