### PR TITLE
Issue #200

### DIFF
--- a/src/function/FunctionEditVars.ts
+++ b/src/function/FunctionEditVars.ts
@@ -167,6 +167,7 @@ export function deletePackageItem(id: string): { add: string[], delete: string[]
         let elem = Object.keys(ProjectElements).find(elem => ProjectElements[elem].connections.includes(target));
         if (elem) ProjectElements[elem].connections.splice(ProjectElements[elem].connections.indexOf(target), 1);
     })
+    VocabularyElements[ProjectElements[id].iri].labels = initLanguageObject("");
     ProjectElements[id].connections = [];
     if (graph.getCell(id)) {
         graph.removeCells([graph.getCell(id)]);

--- a/src/main/NewElemModal.tsx
+++ b/src/main/NewElemModal.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import {Button, Form, InputGroup, Modal} from "react-bootstrap";
 import {PackageNode} from "../datatypes/PackageNode";
-import {Languages, PackageRoot, ProjectSettings, Schemes, VocabularyElements} from "../config/Variables";
+import {
+	Languages,
+	PackageRoot,
+	ProjectElements,
+	ProjectSettings,
+	Schemes,
+	VocabularyElements
+} from "../config/Variables";
 import {Locale} from "../config/Locale";
 import {createNewElemIRI} from "../function/FunctionCreateVars";
 import {initLanguageObject} from "../function/FunctionEditVars";
@@ -36,7 +43,8 @@ export default class NewElemModal extends React.Component<Props, State> {
 		let newIRI = createNewElemIRI(this.state.selectedPackage.scheme, name);
 		return (Object.keys(VocabularyElements)
 			.filter(iri => VocabularyElements[iri].inScheme === this.state.selectedPackage.scheme).find(iri =>
-				(iri === newIRI) || Object.values(VocabularyElements[iri].labels).find(
+				(iri === newIRI && Object.keys(ProjectElements).find(elem => ProjectElements[elem].active &&
+					ProjectElements[elem].iri === iri)) || Object.values(VocabularyElements[iri].labels).find(
 				label => label.trim().toLowerCase() === name.trim().toLowerCase())) !== undefined);
 	}
 

--- a/src/panels/element/PackageItem.tsx
+++ b/src/panels/element/PackageItem.tsx
@@ -46,7 +46,8 @@ export default class PackageItem extends React.Component<Props, State> {
 	getLabel(): JSX.Element {
 		return <span className={"label"}>
 				{getLabelOrBlank(VocabularyElements[ProjectElements[this.props.id].iri].labels, this.props.projectLanguage)}
-			{VocabularyElements[ProjectElements[this.props.id].iri].altLabels.length > 0 &&
+			{VocabularyElements[ProjectElements[this.props.id].iri].altLabels
+				.filter(alt => alt.language === this.props.projectLanguage).length > 0 &&
             <span className={"altLabel"}>
 				&nbsp;{"(" + VocabularyElements[ProjectElements[this.props.id].iri].altLabels
 				.filter(alt => alt.language === this.props.projectLanguage)


### PR DESCRIPTION
## Info:
* Closes #200.
* Fixed an issue where alt labels in languages other than the display languages caused `()` to show in the left panel.
* You may merge this branch.
## Deploy previews:
* [JaKl Obchodní rejstřík](https://deploy-preview-213--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance201242184)
* [V-SGoV pro číselníky](https://deploy-preview-213--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance-145753951)
* [GSGoV klasifikací a číselníků](https://deploy-preview-213--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance2045554666)
* [Sbírka](https://deploy-preview-213--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance1178651091)
* [mm-test](https://deploy-preview-213--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance-2000996011)
* [Marie test](https://deploy-preview-213--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance-530560086)
* [Datové fondy VS](https://deploy-preview-213--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance-1153182747)
* [ontoGrapher test](https://deploy-preview-213--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance1087289886)
* [ML test](https://deploy-preview-213--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance-1101091271)
* [Karel TestX](https://deploy-preview-213--ontographer.netlify.app/?workspace=https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance1170301076)