### PR TITLE
Startup slowdown/freeze fix

### DIFF
--- a/src/interface/SPARQLInterface.ts
+++ b/src/interface/SPARQLInterface.ts
@@ -68,7 +68,8 @@ export async function fetchConcepts(
         "OPTIONAL {?term z-sgov-pojem:charakterizuje ?character.}",
         "OPTIONAL {?term rdfs:domain ?termDomain.}",
         "OPTIONAL {?term rdfs:range ?termRange.}",
-        "OPTIONAL {?term rdfs:subClassOf ?subClassOf. }",
+        "OPTIONAL {?term rdfs:subClassOf ?subClassOf. ",
+        "filter (!isBlank(?subClassOf)) }",
         "OPTIONAL {?term owl:inverseOf ?inverseOf. }",
         "OPTIONAL {?topConcept skos:hasTopConcept ?term. }",
         "OPTIONAL {?term rdfs:subClassOf ?restriction. ",
@@ -148,6 +149,7 @@ export async function getAllTypes(iri: string, endpoint: string, targetTypes: st
                 "WHERE {",
                 "<" + subc + "> a ?type.",
                 "<" + subc + "> rdfs:subClassOf ?subClass.",
+                "filter (!isBlank(?subClassOf))",
                 "OPTIONAL {<" + subc + "> rdfs:subClassOf ?restriction. ",
                 "?restriction a owl:Restriction .",
                 "?restriction owl:onProperty ?onProperty.",
@@ -333,8 +335,8 @@ export async function getSettings(contextIRI: string, contextEndpoint: string): 
             }
             Diagrams[parseInt(result.index.value)].name = result.name.value;
             if (result.color) ProjectSettings.viewColorPool = result.color.value;
-            setSchemeColors(ProjectSettings.viewColorPool);
         }
+        setSchemeColors(ProjectSettings.viewColorPool);
         return true;
     }).catch((e) => {
         console.log(e);


### PR DESCRIPTION
## Info:
* Fixed the workspace fetching query so that it doesn't hog up system resources.
* Fixed an issue where vocabulary colors weren't initialized in new workspaces.  
* Can be merged right away.
## Deploy previews:
[ML Test](https://deploy-preview-229--ontographer.netlify.app/?workspace=https://slovn%C3%ADk.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/pojem/metadatov%C3%BD-kontext/instance-1101091271)
[Datové fondy VS](https://deploy-preview-229--ontographer.netlify.app/?workspace=https://slovn%C3%ADk.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/pojem/metadatov%C3%BD-kontext/instance-1153182747)
[Marie test](https://deploy-preview-229--ontographer.netlify.app/?workspace=https://slovn%C3%ADk.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/pojem/metadatov%C3%BD-kontext/instance-530560086)
[mm-test](https://deploy-preview-229--ontographer.netlify.app/?workspace=https://slovn%C3%ADk.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/pojem/metadatov%C3%BD-kontext/instance-2000996011)
[Sčítání lidu](https://deploy-preview-229--ontographer.netlify.app/?workspace=https://slovn%C3%ADk.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/pojem/metadatov%C3%BD-kontext/instance-2011762727)
[OFN číselníky a klasifikace](https://deploy-preview-229--ontographer.netlify.app/?workspace=https://slovn%C3%ADk.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/pojem/metadatov%C3%BD-kontext/instance-1810443144)
[Sbírka](https://deploy-preview-229--ontographer.netlify.app/?workspace=https://slovn%C3%ADk.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/pojem/metadatov%C3%BD-kontext/instance1483547911)
[Karel Test](https://deploy-preview-229--ontographer.netlify.app/?workspace=https://slovn%C3%ADk.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/pojem/metadatov%C3%BD-kontext/instance479103759)
[Právnické a fyzické osoby v rejstřících](https://deploy-preview-229--ontographer.netlify.app/?workspace=https://slovn%C3%ADk.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/pojem/metadatov%C3%BD-kontext/instance-1872291546)
[Registr práv a povinností](https://deploy-preview-229--ontographer.netlify.app/?workspace=https://slovn%C3%ADk.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/pojem/metadatov%C3%BD-kontext/instance692872026)
[čas](https://deploy-preview-229--ontographer.netlify.app/?workspace=https://slovn%C3%ADk.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/pojem/metadatov%C3%BD-kontext/instance-1171923964)
[Správný model konkrétního číselníku](https://deploy-preview-229--ontographer.netlify.app/?workspace=https://slovn%C3%ADk.gov.cz/datov%C3%BD/pracovn%C3%AD-prostor/pojem/metadatov%C3%BD-kontext/instance570218201)