### PR TITLE
Enhancement #332

### DIFF
--- a/src/locale/cs.ts
+++ b/src/locale/cs.ts
@@ -121,6 +121,7 @@ export const cs: { [Property in keyof typeof en]: string } = {
   definitions: "Popisy",
   representationCompactSwitch: "Přepnout na kompaktní pohled",
   representationFullSwitch: "Přepnout na úplný pohled",
+  generateDiagramImageWithIRIData: "Vložit data o pohledu a IRI do SVG",
   showStereotypes: "Ukázat stereotypy",
   showIncompatibleLinks: "Ukázat nekompatibilní vazby",
   hideStereotypes: "Skrýt stereotypy",

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -113,6 +113,7 @@ export const en = {
   definitions: "Definitions",
   representationCompactSwitch: "Switch to Compact view",
   representationFullSwitch: "Switch to Full view",
+  generateDiagramImageWithIRIData: "Embed view & IRI data into SVG",
   showStereotypes: "View stereotypes",
   showIncompatibleLinks: "Display incompatible links",
   hideStereotypes: "Hide stereotypes",

--- a/src/panels/menu/modal/SaveDiagramsModal.tsx
+++ b/src/panels/menu/modal/SaveDiagramsModal.tsx
@@ -75,6 +75,7 @@ export const SaveDiagramsModal: React.FC<Props> = (props) => {
   const [diagramRepresentation, setDiagramRepresentation] = useState<number>(
     AppSettings.representation
   );
+  const [iriData, setIRIdata] = useState<boolean>(false);
   const [format, setFormat] = useState<string>("PNG");
 
   const saveDiagram: (behaviour: saveBehaviourEnum) => void = (
@@ -125,6 +126,30 @@ export const SaveDiagramsModal: React.FC<Props> = (props) => {
     svg.setAttribute("width", String(area.width));
     svg.setAttribute("height", String(area.height));
     svg.setAttribute("viewbox", `0 0 ${area.width} ${area.height}`);
+    if (format === "SVG" && iriData) {
+      svg.setAttribute(
+        "data-ontographer-view",
+        Representation[diagramRepresentation].toLowerCase()
+      );
+      const termElements = svg.getElementsByClassName("joint-element");
+      for (const index in graph.getElements()) {
+        const element = termElements[index];
+        const id = element.getAttribute("model-id");
+        if (element && id) {
+          const iri = WorkspaceElements[id].iri;
+          termElements[index].setAttribute("data-ontographer-iri", iri);
+        }
+      }
+      const linkElements = svg.getElementsByClassName("joint-link");
+      for (const index in graph.getLinks()) {
+        const element = linkElements[index];
+        const id = element.getAttribute("model-id");
+        if (element && id) {
+          const iri = WorkspaceLinks[id].iri;
+          linkElements[index].setAttribute("data-ontographer-iri", iri);
+        }
+      }
+    }
     let svgText = serializer.serializeToString(svg);
     if (blackWhiteSwitch) {
       svgText = svgText.replaceAll(
@@ -240,7 +265,10 @@ export const SaveDiagramsModal: React.FC<Props> = (props) => {
                 as="select"
                 size={"sm"}
                 value={format}
-                onChange={(event) => setFormat(event.currentTarget.value)}
+                onChange={(event) => {
+                  setFormat(event.currentTarget.value);
+                  if (event.currentTarget.value === "PNG") setIRIdata(false);
+                }}
               >
                 <option key={1} value={"PNG"}>
                   {"PNG"}
@@ -262,6 +290,16 @@ export const SaveDiagramsModal: React.FC<Props> = (props) => {
             onChange={(event) =>
               setBlackWhiteSwitch(event.currentTarget.checked)
             }
+          />
+          <Form.Check
+            disabled={format !== "SVG"}
+            type={"checkbox"}
+            label={
+              Locale[AppSettings.viewLanguage].generateDiagramImageWithIRIData
+            }
+            checked={iriData}
+            id={"setIRIcheckbox"}
+            onChange={(event) => setIRIdata(event.currentTarget.checked)}
           />
         </Form>
         <br />


### PR DESCRIPTION
## Info:
* Resolves #332.
* The representation is under the `data-ontographer-view` attrubute in the `svg` tag.
* The IRIs of links and elements are under the `data-ontographer-iri` attrubute in the `g` tag of class `joint-link` and `joint-element`, respectively.