### PR TITLE
Issue #346

### DIFF
--- a/src/interface/JSONInterface.ts
+++ b/src/interface/JSONInterface.ts
@@ -6,7 +6,10 @@ import {
 } from "../config/Variables";
 import { createValues } from "../function/FunctionCreateVars";
 import { initLanguageObject } from "../function/FunctionEditVars";
-import { checkLabels } from "../function/FunctionGetVars";
+import {
+  checkLabels,
+  getVocabularyFromScheme,
+} from "../function/FunctionGetVars";
 import { Locale } from "../config/Locale";
 import { checkDefaultCardinality } from "../function/FunctionLink";
 import {
@@ -31,8 +34,9 @@ export async function getVocabulariesFromRemoteJSON(
             results.push(
               await fetchVocabulary([data.sourceIRI], true, data.endpoint)
             );
-            WorkspaceVocabularies[data.sourceIRI].labels =
-              initLanguageObject(key);
+            WorkspaceVocabularies[
+              getVocabularyFromScheme(data.sourceIRI)
+            ].labels = initLanguageObject(key);
             results.push(
               await fetchConcepts(
                 data.endpoint,


### PR DESCRIPTION
## Info:
* Closes #346 - faulty loading of stereotypes and link types after (presumably) an SSP update.
* How to test - if you can load a workspace correctly without missing term stereotypes or link types, the fix worked.