### PR TITLE
Issue AL-#61

### DIFF
--- a/src/interface/JSONInterface.ts
+++ b/src/interface/JSONInterface.ts
@@ -1,21 +1,11 @@
-import {
-  AppSettings,
-  Links,
-  Stereotypes,
-  WorkspaceVocabularies,
-} from "../config/Variables";
+import { AppSettings, Links, Stereotypes } from "../config/Variables";
 import { createValues } from "../function/FunctionCreateVars";
-import { initLanguageObject } from "../function/FunctionEditVars";
-import {
-  checkLabels,
-  getVocabularyFromScheme,
-} from "../function/FunctionGetVars";
+import { checkLabels } from "../function/FunctionGetVars";
 import { Locale } from "../config/Locale";
 import { checkDefaultCardinality } from "../function/FunctionLink";
 import {
   fetchConcepts,
   fetchSubClassesAndCardinalities,
-  fetchVocabulary,
 } from "../queries/get/FetchQueries";
 
 export async function getVocabulariesFromRemoteJSON(
@@ -31,12 +21,6 @@ export async function getVocabulariesFromRemoteJSON(
         for (const key of Object.keys(json)) {
           const data = json[key];
           if (data.type === "stereotype") {
-            results.push(
-              await fetchVocabulary([data.sourceIRI], true, data.endpoint)
-            );
-            WorkspaceVocabularies[
-              getVocabularyFromScheme(data.sourceIRI)
-            ].labels = initLanguageObject(key);
             results.push(
               await fetchConcepts(
                 data.endpoint,

--- a/src/queries/get/CacheQueries.ts
+++ b/src/queries/get/CacheQueries.ts
@@ -192,6 +192,9 @@ export async function searchCache(
     "optional {?entity skos:definition ?definition.}",
     "?entity skos:inScheme ?scheme.",
     "?vocabulary <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/má-glosář> ?scheme.",
+    "<" +
+      AppSettings.cacheContext +
+      "> <https://slovník.gov.cz/datový/pracovní-prostor/pojem/odkazuje-na-kontext> ?vocabulary.",
     limitToVocabularies && limitToVocabularies.length > 0
       ? "VALUES ?vocabulary {<" + limitToVocabularies.join("> <") + ">}"
       : "",

--- a/src/queries/get/FetchQueries.ts
+++ b/src/queries/get/FetchQueries.ts
@@ -93,7 +93,7 @@ export async function fetchConcepts(
   requiredTypes?: string[],
   requiredValues?: string[]
 ): Promise<boolean> {
-  let result: {
+  const result: {
     [key: string]: {
       labels: { [key: string]: string };
       definitions: { [key: string]: string };
@@ -235,7 +235,7 @@ export async function fetchConcepts(
         result[term].restrictions = result[term].restrictions.filter((r) =>
           Object.keys(Links).includes(r.onProperty)
         );
-        // Any inverse restriction is, for purposes convenience,
+        // Any inverse restriction is, for purposes of convenience,
         // saved under the original restriction's origin term.
         // This will enable us to implement source cardinality recognition more easily.
         result[term].restrictions


### PR DESCRIPTION
## Info:
* Closes [AL-#61](https://github.com/opendata-mvcr/sgov-assembly-line/issues/61).
* The problem was that the user shouldn't be able to get `Objekt` as a result in the first place, as the term is not in any of the canonical contexts, but in a workspace vocabulary context. Therefore, the correct behaviour is that finding and/or putting such a term on the canvas should be impossible.