### PR TITLE
Milestone1a - diagram reconstruction fix

### DIFF
--- a/src/queries/update/UpdateReconstructAppContext.ts
+++ b/src/queries/update/UpdateReconstructAppContext.ts
@@ -18,16 +18,14 @@ export async function reconstructApplicationContextWithDiagrams(): Promise<strin
   ];
   const diagramRetrievalQuery = [
     "PREFIX og: <http://onto.fel.cvut.cz/ontologies/application/ontoGrapher/>",
-    "select ?diagram where {",
+    "select ?diagram ?graph where {",
     "BIND(<" + AppSettings.contextIRI + "> as ?metaContext).",
     "graph ?metaContext {",
-    `?metaContext ?linkPredicate ?diagram .`,
+    `?metaContext ?linkPredicate ?graph .`,
     `values ?linkPredicate { <${linkPredicates.join("> <")}> }`,
     "}",
-    "graph ?diagram {",
-    `?diagram ${qb.i(
-      parsePrefix("d-sgov-pracovní-prostor-pojem", "má-typ-přílohy")
-    )} og:diagram.`,
+    "graph ?graph {",
+    "?diagram a og:diagram.",
     "}",
     "} limit 1",
   ].join(`


### PR DESCRIPTION
## Info:
* Fixes an issue where initializing a workspace with a diagram attachment wouldn't show the attachment unless OG is refreshed.

In other words, the need to refresh in the last bullet point is removed:
![image](https://user-images.githubusercontent.com/56399637/144802919-bde37d5b-4b31-468b-b784-6fc132f3982d.png)
