### PR TITLE
Fixing issues before planned training

### DIFF
--- a/src/function/FunctionCache.ts
+++ b/src/function/FunctionCache.ts
@@ -188,9 +188,8 @@ export function insertNewCacheTerms(newTerms: typeof WorkspaceTerms) {
           newTerms[term].inScheme
         );
         setSchemeColors(AppSettings.viewColorPool);
-      } else {
-        changeVocabularyCount(vocab, (count) => count + 1, term);
       }
+      changeVocabularyCount(vocab, (count) => count + 1, term);
     } else
       console.error(
         `Vocabulary with glossary ${newTerms[term].inScheme} has not been found in the database; term ${term} will not be added.`

--- a/src/function/FunctionCreateVars.ts
+++ b/src/function/FunctionCreateVars.ts
@@ -154,7 +154,7 @@ export function addDiagram(
     index =
       Object.keys(Diagrams).length > 0
         ? Object.values(Diagrams).reduce((a, b) => (a.index > b.index ? a : b))
-            .index
+            .index + 1
         : 0;
   Diagrams[diagramID] = {
     name: name,

--- a/src/function/FunctionDraw.ts
+++ b/src/function/FunctionDraw.ts
@@ -7,7 +7,11 @@ import {
 } from "../config/Variables";
 import { getStereotypeList, setElementShape } from "./FunctionEditVars";
 import { Representation } from "../config/Enum";
-import { getElementShape, getIntrinsicTropeTypeIDs } from "./FunctionGetVars";
+import {
+  getElementShape,
+  getIntrinsicTropeTypeIDs,
+  getLabelOrBlank,
+} from "./FunctionGetVars";
 import { ElementColors } from "../config/visual/ElementColors";
 import _ from "underscore";
 
@@ -25,7 +29,7 @@ export function setDisplayLabel(id: string, languageCode: string) {
 export function getDisplayLabel(id: string, languageCode: string): string {
   if (!WorkspaceElements[id].selectedLabel[languageCode])
     setDisplayLabel(id, languageCode);
-  return WorkspaceElements[id].selectedLabel[languageCode];
+  return getLabelOrBlank(WorkspaceElements[id].selectedLabel, languageCode);
 }
 
 export function drawGraphElement(
@@ -47,12 +51,12 @@ export function drawGraphElement(
     const text: string[] = [];
     if (representation === Representation.COMPACT) {
       text.push(
-        ...getIntrinsicTropeTypeIDs(elem.id).map((id) =>
+        ..._.uniq(getIntrinsicTropeTypeIDs(elem.id)).map((id) =>
           getDisplayLabel(id, languageCode)
         )
       );
     }
-    elem.prop("attrs/labelAttrs/text", _.uniq(text).join("\n"));
+    elem.prop("attrs/labelAttrs/text", text.join("\n"));
     const width =
       representation === Representation.COMPACT
         ? Math.max(

--- a/src/panels/VocabularyPanel.tsx
+++ b/src/panels/VocabularyPanel.tsx
@@ -266,14 +266,15 @@ export default class VocabularyPanel extends React.Component<Props, State> {
           );
         }
       }
+      const vocabulary = getVocabularyFromScheme(node.scheme);
       if (
-        this.state.vocabs.find(
-          (vocab) => vocab.value === getVocabularyFromScheme(node.scheme)
-        ) ||
-        (this.state.vocabs.length === 0 && vocabularyConcepts.length > 0) ||
+        this.state.vocabs.find((vocab) => vocab.value === vocabulary) ||
         (this.state.vocabs.length === 0 &&
-          vocabularyConcepts.length === 0 &&
-          !this.state.search)
+          (vocabularyConcepts.length > 0 ||
+            (vocabularyConcepts.length === 0 &&
+              !this.state.search &&
+              vocabulary in WorkspaceVocabularies &&
+              !WorkspaceVocabularies[vocabulary].readOnly)))
       )
         result.push(
           <VocabularyFolder

--- a/src/queries/get/FetchQueries.ts
+++ b/src/queries/get/FetchQueries.ts
@@ -40,7 +40,7 @@ export async function fetchVocabulary(
     "values " +
       (scheme ? "?scheme" : "?vocabulary") +
       " {<" +
-      iris.join(">, <") +
+      iris.join("> <") +
       ">}",
     "}",
   ].join(" ");


### PR DESCRIPTION
## Info:
* Fixes issue where creating a new read-only vocabulary with a new term read as a vocabulary with 0 terms.
* Fixes issue where a newly created diagram reoriented itself to be second last after refresh.
* Fixes issue where `<blank>` wouldn't show for intrinsic tropes in Compact mode.
* Fixes issue where read-only vocabularies wouldn't disappear when it has had all terms removed.