### PR TITLE
Issue #377

### DIFF
--- a/src/queries/get/CacheQueries.ts
+++ b/src/queries/get/CacheQueries.ts
@@ -188,9 +188,11 @@ export async function searchCache(
     "[] a con-inst:" + lucene + " ;",
     'con:query "' + term + '" ;',
     "con:entities ?entity .",
+    "graph ?vocabulary {",
     "?entity skos:prefLabel ?label.",
     "optional {?entity skos:definition ?definition.}",
     "?entity skos:inScheme ?scheme.",
+    "}",
     "?vocabulary <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/má-glosář> ?scheme.",
     "<" +
       AppSettings.cacheContext +


### PR DESCRIPTION
## Info:
* Closes #377.
* Another case of "you shouldn't have gotten this as a result"; the correct behaviour is that Jednotka from částky shouldn't be reached from the search (at this time it is only in a context; not in the central repository).