### PR TITLE
Fix synonym section showing up for generalizations

### DIFF
--- a/src/panels/detail/DetailLink.tsx
+++ b/src/panels/detail/DetailLink.tsx
@@ -390,7 +390,9 @@ export default class DetailLink extends React.Component<Props, State> {
                     }))
                   }
                 />
-                {AppSettings.representation === Representation.COMPACT && (
+                {(AppSettings.representation === Representation.COMPACT
+                  && this.props.id in WorkspaceLinks
+                  && WorkspaceLinks[this.props.id].type === LinkType.DEFAULT) && (
                   <div>
                     <h5>
                       {


### PR DESCRIPTION
## Info:
* Fixes an issue where the synonym (altLabel) section in the detail panel would show up for generalizations.