### PR TITLE
Change attachment namespace from a-popis-dat to slovník-gov

### DIFF
--- a/src/config/Variables.ts
+++ b/src/config/Variables.ts
@@ -72,6 +72,7 @@ export var Prefixes: { [key: string]: string } = {
   "v-sgov-pojem": "https://slovník.gov.cz/veřejný-sektor/pojem/",
   "a-popis-dat-pojem":
     "http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/",
+  "slovník-gov": "https://slovník.gov.cz/",
 };
 
 export var WorkspaceTerms: {

--- a/src/function/FunctionGetVars.ts
+++ b/src/function/FunctionGetVars.ts
@@ -220,7 +220,7 @@ export function getNewDiagramContextIRI(id: string) {
 }
 
 export function getNewDiagramIRI(id: string): string {
-  return parsePrefix("a-popis-dat-pojem", `příloha/instance-${id}`);
+  return parsePrefix("slovník-gov", `příloha/instance-${id}`);
 }
 
 export function isLabelBlank(label: string) {


### PR DESCRIPTION
## Info:
* Changes attachment namespace according to [SSP PR #447](https://github.com/opendata-mvcr/ssp/pull/477).