### PR TITLE
Vocabulary-level change tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5576,9 +5576,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001358",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
-      "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==",
+      "version": "1.0.30001439",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
+      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
       "funding": [
         {
           "type": "opencollective",
@@ -7488,14 +7488,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
       "engines": {
         "node": ">=8"
       }
@@ -16676,6 +16668,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/react-scripts/node_modules/fs-extra": {
@@ -27077,9 +27077,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001358",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
-      "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw=="
+      "version": "1.0.30001439",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
+      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -28588,11 +28588,6 @@
           "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
         }
       }
-    },
-    "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -35746,6 +35741,11 @@
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.1.tgz",
           "integrity": "sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA=="
+        },
+        "dotenv": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+          "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
         },
         "fs-extra": {
           "version": "9.1.0",

--- a/src/config/ChangeTypes.ts
+++ b/src/config/ChangeTypes.ts
@@ -1,0 +1,28 @@
+export enum ChangeType {
+  ADDITION,
+  EDIT,
+  // and deletion? Such a change is not in the a-popis-dat ontology.
+}
+
+// Logging only changes of the vocabulary. OG-specific attribute change tracking is currently unimplemented.
+export var ChangeAttribute = {
+  element: {
+    prefLabel: "http://www.w3.org/2004/02/skos/core#prefLabel",
+    altLabel: "http://www.w3.org/2004/02/skos/core#altLabel",
+    definition: "http://www.w3.org/2004/02/skos/core#definition",
+    type: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+    title: "http://purl.org/dc/terms/title",
+    scheme: "http://www.w3.org/2004/02/skos/core#",
+    topConcept: "http://www.w3.org/2004/02/skos/core#",
+  },
+  // TODO: implement change tracking for relationships
+};
+
+export type Change = {
+  type: ChangeType;
+  vocabulary: string;
+  attribute: string;
+  entity: string;
+  current: string;
+  replace: string;
+};

--- a/src/config/ChangeTypes.ts
+++ b/src/config/ChangeTypes.ts
@@ -12,8 +12,8 @@ export var ChangeAttribute = {
     definition: "http://www.w3.org/2004/02/skos/core#definition",
     type: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
     title: "http://purl.org/dc/terms/title",
-    scheme: "http://www.w3.org/2004/02/skos/core#",
-    topConcept: "http://www.w3.org/2004/02/skos/core#",
+    inScheme: "http://www.w3.org/2004/02/skos/core#inScheme",
+    topConcept: "http://www.w3.org/2004/02/skos/core#topConceptOf",
   },
   // TODO: implement change tracking for relationships
 };

--- a/src/config/Variables.ts
+++ b/src/config/Variables.ts
@@ -55,6 +55,7 @@ export var WorkspaceVocabularies: {
     namespace: string;
     graph: string;
     color: string;
+    changeContext?: string;
   };
 } = {};
 
@@ -157,6 +158,13 @@ export var AppSettings: {
   interfaceLanguage: string;
   selectedElements: string[];
   selectedLinks: string[];
+  currentUser?: {
+    email: string;
+    given_name: string;
+    family_name: string;
+    id: string;
+  };
+  changedVocabularies: string[];
 } = {
   name: {},
   description: {},
@@ -186,6 +194,7 @@ export var AppSettings: {
   interfaceLanguage: "en",
   selectedElements: [],
   selectedLinks: [],
+  changedVocabularies: [],
 };
 
 export var CardinalityPool: Cardinality[] = [

--- a/src/interface/ContextInterface.tsx
+++ b/src/interface/ContextInterface.tsx
@@ -242,8 +242,9 @@ export async function retrieveVocabularyData(): Promise<boolean> {
     );
     WorkspaceVocabularies[vocab].readOnly = false;
     WorkspaceVocabularies[vocab].graph = vocabularies[vocab].graph;
-    WorkspaceVocabularies[vocab].changeContext =
-      vocabularies[vocab].changeContext;
+    if (vocabularies[vocab].changeContext)
+      WorkspaceVocabularies[vocab].changeContext =
+        vocabularies[vocab].changeContext;
     Object.assign(WorkspaceTerms, vocabularies[vocab].terms);
   }
   const numberOfVocabularies = Object.keys(vocabularies).length;

--- a/src/interface/ContextInterface.tsx
+++ b/src/interface/ContextInterface.tsx
@@ -161,9 +161,13 @@ export async function retrieveVocabularyData(): Promise<boolean> {
     "PREFIX termit: <http://onto.fel.cvut.cz/ontologies/application/termit/>",
     "PREFIX a-popis-dat-pojem: <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/>",
     "PREFIX dcterms: <http://purl.org/dc/terms/>",
-    "select ?contextIRI ?scheme ?vocabLabel ?vocabIRI",
+    "select ?contextIRI ?scheme ?vocabLabel ?vocabIRI ?changeContext",
     "where {",
     "graph ?contextIRI {",
+    `OPTIONAL { ?vocabulary <${parsePrefix(
+      "d-sgov-pracovní-prostor-pojem",
+      "má-kontext-sledování-změn"
+    )}> ?changeContext. }`,
     "?vocabIRI a a-popis-dat-pojem:slovník .",
     "?vocabIRI a-popis-dat-pojem:má-glosář ?scheme.",
     "?vocabIRI dcterms:title ?vocabLabel .",
@@ -178,6 +182,7 @@ export async function retrieveVocabularyData(): Promise<boolean> {
       terms: typeof WorkspaceTerms;
       graph: string;
       glossary: string;
+      changeContext?: string;
     };
   } = {};
   const responseInit: boolean = await processQuery(
@@ -196,6 +201,9 @@ export async function retrieveVocabularyData(): Promise<boolean> {
             glossary: result.scheme.value,
           };
         }
+        if (result.changeContext)
+          vocabularies[result.vocabIRI.value].changeContext =
+            result.changeContext.value;
         vocabularies[result.vocabIRI.value].names[
           result.vocabLabel["xml:lang"]
         ] = result.vocabLabel.value;
@@ -234,6 +242,8 @@ export async function retrieveVocabularyData(): Promise<boolean> {
     );
     WorkspaceVocabularies[vocab].readOnly = false;
     WorkspaceVocabularies[vocab].graph = vocabularies[vocab].graph;
+    WorkspaceVocabularies[vocab].changeContext =
+      vocabularies[vocab].changeContext;
     Object.assign(WorkspaceTerms, vocabularies[vocab].terms);
   }
   const numberOfVocabularies = Object.keys(vocabularies).length;

--- a/src/main/App.tsx
+++ b/src/main/App.tsx
@@ -50,6 +50,8 @@ import { getElementPosition } from "../function/FunctionElem";
 import { en } from "../locale/en";
 import { StoreAlerts } from "../config/Store";
 import { CriticalAlertModal } from "../components/modals/CriticalAlertModal";
+import * as _ from "lodash";
+import { updateVocabularyAnnotations } from "../queries/update/UpdateChangeQueries";
 
 interface DiagramAppProps {}
 
@@ -214,7 +216,13 @@ export default class App extends React.Component<
       this.handleWorkspaceReady();
       return;
     }
-    const transaction = qb.constructQuery(...queriesTrimmed);
+    const transaction = qb.constructQuery(
+      ...queriesTrimmed,
+      ..._.uniq(AppSettings.changedVocabularies).map((v) =>
+        updateVocabularyAnnotations(v)
+      )
+    );
+    AppSettings.changedVocabularies = [];
     this.handleStatus(
       true,
       Locale[AppSettings.interfaceLanguage].updating,

--- a/src/panels/MenuPanel.tsx
+++ b/src/panels/MenuPanel.tsx
@@ -9,7 +9,7 @@ import MenuPanelHelp from "./menu/right/MenuPanelHelp";
 import { MenuPanelSaveDiagrams } from "./menu/left/MenuPanelSaveDiagrams";
 import ZoomWidget from "./menu/widget/ZoomWidget";
 import InterfaceNotification from "../components/InterfaceNotification";
-import MenuPanelLogout from "./menu/right/MenuPanelLogout";
+import { MenuPanelLogout } from "./menu/right/MenuPanelLogout";
 import ViewWidget from "./menu/widget/ViewWidget";
 import MenuPanelAbout from "./menu/right/MenuPanelAbout";
 import MenuPanelValidate from "./menu/left/MenuPanelValidate";

--- a/src/panels/menu/right/MenuPanelLogout.tsx
+++ b/src/panels/menu/right/MenuPanelLogout.tsx
@@ -1,11 +1,21 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Nav } from "react-bootstrap";
 import { useAuth } from "@opendata-mvcr/assembly-line-shared";
 import { Locale } from "../../../config/Locale";
 import { AppSettings } from "../../../config/Variables";
 
-export default function MenuPanelLogout() {
-  const { logout } = useAuth();
+export const MenuPanelLogout: React.FC = () => {
+  const { logout, user } = useAuth();
+
+  useEffect(() => {
+    AppSettings.currentUser = {
+      given_name: user.profile.given_name,
+      email: user.profile.email,
+      family_name: user.profile.family_name,
+      id: user.profile.sub,
+    };
+  }, [user]);
+
   return (
     <div className={"inert"}>
       <Nav.Link onClick={logout}>
@@ -13,4 +23,4 @@ export default function MenuPanelLogout() {
       </Nav.Link>
     </div>
   );
-}
+};

--- a/src/queries/update/UpdateChangeQueries.ts
+++ b/src/queries/update/UpdateChangeQueries.ts
@@ -1,0 +1,134 @@
+import { Environment } from "./../../config/Environment";
+import { AppSettings, WorkspaceVocabularies } from "./../../config/Variables";
+import { DELETE, INSERT } from "@tpluscode/sparql-builder";
+import { qb } from "../QueryBuilder";
+import { parsePrefix } from "../../function/FunctionEditVars";
+import { v4 as uuidv4 } from "uuid";
+import { ChangeType, Change } from "../../config/ChangeTypes";
+
+function getUserIRI(): string {
+  return `${AppSettings.cacheContext}/uživatel/${AppSettings.currentUser!.id}`;
+}
+
+export function updateVocabularyAnnotations(vocabulary: string): string {
+  if (!Environment.auth)
+    throw new Error(
+      "Attemted to update vocabulary annotations without a signed-in user."
+    );
+  if (WorkspaceVocabularies[vocabulary].readOnly)
+    throw new Error(
+      `Attemted to track changes for a read-only vocabulary ${vocabulary}.`
+    );
+  const context = WorkspaceVocabularies[vocabulary].graph;
+  const queryInsert = INSERT.DATA`${qb.g(context, [
+    qb.s(
+      qb.i(context),
+      qb.i(parsePrefix("a-popis-dat-pojem", "má-posledního-editora")),
+      qb.i(getUserIRI())
+    ),
+    qb.s(
+      qb.i(context),
+      qb.i(
+        parsePrefix("a-popis-dat-pojem", "má-datum-a-čas-poslední-modifikace")
+      ),
+      qb.lt(new Date().toISOString(), "xsd:dateTime")
+    ),
+  ])}`.build();
+
+  const deleteStatements = qb.g(context, [
+    qb.s(
+      qb.i(context),
+      qb.i(parsePrefix("a-popis-dat-pojem", "má-posledního-editora")),
+      "?e"
+    ),
+    qb.s(
+      qb.i(context),
+      qb.i(
+        parsePrefix("a-popis-dat-pojem", "má-datum-a-čas-poslední-modifikace")
+      ),
+      "?d"
+    ),
+  ]);
+
+  const queryDelete = DELETE`${deleteStatements}`
+    .WHERE`${deleteStatements}`.build();
+  return qb.combineQueries(queryDelete, queryInsert);
+}
+
+function getChangeType(type: ChangeType): string {
+  if (type === ChangeType.ADDITION)
+    return parsePrefix("a-popis-dat-pojem", "vytvoření-entity");
+  if (type === ChangeType.EDIT)
+    return parsePrefix("a-popis-dat-pojem", "úprava-entity");
+  throw new Error("Received an unexpected ChangeType.");
+}
+
+function constructChangeTrackingQuery(change: Change): string {
+  if (!WorkspaceVocabularies[change.vocabulary].changeContext)
+    throw new Error(
+      `Change context not found for vocabulary ${change.vocabulary}.`
+    );
+  if (WorkspaceVocabularies[change.vocabulary].readOnly)
+    throw new Error(
+      `Attemted to track changes for a read-only vocabulary ${change.vocabulary}.`
+    );
+  if (!Environment.auth)
+    throw new Error(
+      "Attemted to update vocabulary annotations without a signed-in user."
+    );
+  const type = getChangeType(change.type);
+  //TODO: change ID generation to conform to Termit implementation
+  const suffix = `/instance-${uuidv4()}`;
+  const iri = qb.i(type + suffix);
+  return qb.combineQueries(
+    INSERT.DATA`${qb.g(
+      WorkspaceVocabularies[change.vocabulary].changeContext!,
+      [
+        qb.s(iri, "rdf:type", qb.i(type)),
+        qb.s(
+          iri,
+          parsePrefix("a-popis-dat-pojem", "má-editora"),
+          qb.i(getUserIRI())
+        ),
+        qb.s(
+          iri,
+          qb.i(parsePrefix("a-popis-dat-pojem", "má-datum-a-čas-modifikace")),
+          qb.lt(new Date().toISOString(), "xsd:dateTime")
+        ),
+        qb.s(
+          iri,
+          parsePrefix("a-popis-dat-pojem", "má-změněnou-entitu"),
+          qb.i(change.entity)
+        ),
+        // If this is just an addition change (i.e. creation of a new term), we stop here. Otherwise, we continue logging additional details:
+        ...(change.type === ChangeType.EDIT
+          ? [
+              qb.s(
+                iri,
+                parsePrefix("a-popis-dat-pojem", "má-změněný-atribut"),
+                qb.i(change.attribute)
+              ),
+              qb.s(
+                iri,
+                parsePrefix("a-popis-dat-pojem", "má-původní-hodnotu"),
+                change.current
+              ),
+              qb.s(
+                iri,
+                parsePrefix("a-popis-dat-pojem", "má-novou-hodnotu"),
+                change.replace
+              ),
+            ]
+          : []),
+      ]
+    )}`.build()
+  );
+}
+
+// TODO: implement entity/attribute change tracking
+export function updateChanges(...changes: Change[]): string {
+  return qb.combineQueries(
+    ...changes.map((c) => updateVocabularyAnnotations(c.vocabulary)),
+    ...changes.map((c) => constructChangeTrackingQuery(c))
+  );
+}

--- a/src/queries/update/UpdateConnectionQueries.ts
+++ b/src/queries/update/UpdateConnectionQueries.ts
@@ -1,3 +1,4 @@
+import { AppSettings } from "./../../config/Variables";
 import {
   Links,
   WorkspaceElements,
@@ -238,6 +239,10 @@ export function updateDefaultLink(id: string): string {
     contextIRI,
     _.uniq(constructDefaultLinkRestrictions(...insertConnections))
   )}`.build();
+  if (del && insert)
+    AppSettings.changedVocabularies.push(
+      getVocabularyFromScheme(WorkspaceTerms[iri].inScheme)
+    );
   return qb.combineQueries(del, insert);
 }
 
@@ -277,6 +282,10 @@ export function updateGeneralizationLink(id: string): string {
   const insert = INSERT.DATA`${qb.g(contextIRI, [
     qb.s(qb.i(iri), "rdfs:subClassOf", qb.a(subClasses), subClasses.length > 0),
   ])}`.build();
+  if (del && insert)
+    AppSettings.changedVocabularies.push(
+      getVocabularyFromScheme(WorkspaceTerms[iri].inScheme)
+    );
   return qb.combineQueries(del, insert);
 }
 

--- a/src/queries/update/UpdateElementQueries.ts
+++ b/src/queries/update/UpdateElementQueries.ts
@@ -129,6 +129,9 @@ export function updateProjectElement(del: boolean, ...iris: string[]): string {
         )
       );
     }
+    AppSettings.changedVocabularies.push(
+      getVocabularyFromScheme(WorkspaceTerms[iri].inScheme)
+    );
   }
 
   for (const vocab in data) {


### PR DESCRIPTION
## Info:
* Inserts the following data into the workspace's vocabulary context on vocabulary change (e.g. term creation, attribute change, etc.):

> \<vocabulary-context> a-popis-dat:má-datum-a-čas-poslední-modifikace [dateTime of change].
>
> \<vocabulary-context> a-popis:dat:má-posledního-editora \<https:slovník.gov.cz/uživatel/[signed in user ID]>.