### PR TITLE
[Fix] Add auth token to check status request to prevent 401 errors when repository access is protected

### DIFF
--- a/src/components/InterfaceNotification.tsx
+++ b/src/components/InterfaceNotification.tsx
@@ -6,6 +6,7 @@ import { Environment } from "../config/Environment";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import green from "@mui/material/colors/green";
+import { getToken } from "@opendata-mvcr/assembly-line-shared";
 
 const theme = createTheme({
   palette: {
@@ -91,7 +92,10 @@ export default class InterfaceNotification extends React.Component<
         AppSettings.contextEndpoint +
           "?query=select%20*%20where%20%7B%3Fs%20%3Fp%20%3Fo.%7D%20limit%201",
         {
-          headers: { Accept: "application/json" },
+          headers: {
+            Accept: "application/json",
+            ...(Environment.auth && { Authorization: `${getToken()}` }),
+          },
           method: "GET",
           signal,
         }


### PR DESCRIPTION
Status checks were throwing 401 errors when repository security was enabled. I found that the request did not contain Authorization header.

Please, merge also into standalone.